### PR TITLE
Add Handy support: flake input, keybinding, services, and docs

### DIFF
--- a/docs/keyboard-shortcuts/niri-shortcuts.md
+++ b/docs/keyboard-shortcuts/niri-shortcuts.md
@@ -10,6 +10,7 @@ These keyboard shortcuts are configured in `modules/home/niri/niri.nix`.
 |---|---|
 | `Super + Return` | launch terminal (kitty) |
 | `Super + D` | launch application launcher (fuzzel) |
+| `Right Super + AltGr` | toggle Handy transcription |
 
 ## Window Management (Focus)
 

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,10 @@
       url = "github:sodiboo/niri-flake";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    handy = {
+      url = "github:cjpais/Handy";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
+    };
     kanagawa-yazi = {
       # Yazi color theme
       url = "github:dangooddd/kanagawa.yazi";
@@ -46,6 +50,7 @@
       nixvim,
       sops-nix,
       niri,
+      handy,
       kanagawa-yazi,
       ...
     }@inputs:
@@ -84,6 +89,7 @@
           };
           modules = [
             inputs.sops-nix.nixosModules.sops
+            inputs.handy.nixosModules.default
             ./hosts/laptop/default.nix
           ];
         };

--- a/home/vii/home-linux.nix
+++ b/home/vii/home-linux.nix
@@ -22,6 +22,8 @@ in
   programs.fish.enable = true;
   programs.direnv.enable = true;
 
+  services.handy.enable = true;
+
   # Secrets (sops-nix)
   #
   # IMPORTANT: Do not embed secret values in Nix options (they end up in the Nix store).

--- a/hosts/laptop/default.nix
+++ b/hosts/laptop/default.nix
@@ -38,7 +38,27 @@
     enable = true;
     package = pkgs.docker_29;
   };
-  users.users.vii.extraGroups = [ "docker" ];
+  users.users.vii.extraGroups = [
+    "docker"
+    "input"
+  ];
+
+  programs.handy.enable = true;
+
+  services.keyd = {
+    enable = true;
+    keyboards.default = {
+      ids = [ "*" ];
+      settings = {
+        global = {
+          chord_timeout = 100;
+        };
+        main = {
+          "rightmeta+rightalt" = "f20";
+        };
+      };
+    };
+  };
 
   # Fonts
   fonts.packages = with pkgs; [
@@ -58,6 +78,7 @@
   home-manager.sharedModules =  # Home Manager modules shared between all users
     [
       inputs.sops-nix.homeManagerModules.sops
+      inputs.handy.homeManagerModules.default
       inputs.nixvim.homeModules.nixvim
       ../../modules/home/kitty.nix
       ../../modules/home/ghostty.nix

--- a/modules/home/niri/niri.nix
+++ b/modules/home/niri/niri.nix
@@ -81,6 +81,7 @@
         # Mod key (Super/Windows key)
         "Mod+Return".action.spawn = "kitty";
         "Mod+D".action.spawn = "fuzzel";
+        "F20".action.spawn = [ "handy" "--toggle-transcription" ];
         
         # Window management
         "Mod+Q".action.close-window = {};
@@ -196,6 +197,7 @@
     wl-clipboard   # Clipboard utilities
     brightnessctl  # Brightness control
     pavucontrol    # Audio control GUI
+    wtype          # Wayland text injection for Handy transcriptions
     xwayland-satellite # X11 compatibility layer (Crucial for newer Niri)
     xdg-desktop-portal-gnome # Needed for file pickers etc in Electron apps
     polkit_gnome   # Authentication agent


### PR DESCRIPTION
### Motivation

- Add support for the Handy speech transcription tool and expose a toggle keybinding from the Niri window manager.
- Provide a reliable key event for Handy by mapping a physical chord to a function key via `keyd` and grant the user the `input` group for access.

### Description

- Add `handy` as a flake input and wire its NixOS and Home Manager modules into the flake outputs via `inputs.handy.nixosModules.default` and `inputs.handy.homeManagerModules.default`.
- Enable `programs.handy`/`services.handy` in the per-user and host configs via `programs.handy.enable = true` and `services.handy.enable = true`.
- Add a `keyd` service configuration mapping the `rightmeta+rightalt` chord to `F20` and add a Niri binding `F20` to spawn `handy --toggle-transcription` in `modules/home/niri/niri.nix`.
- Update user/groups (`users.users.vii.extraGroups` adds `input`), add `wtype` to packages, and document the new shortcut in `docs/keyboard-shortcuts/niri-shortcuts.md`.

### Testing

- Ran `nix flake check` against the repository, which completed successfully.
- Built the laptop system configuration with `nixos-rebuild build` for the `laptop` target, which succeeded.
- Performed a `home-manager build` for user `vii` to validate Home Manager module wiring, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3187702150832b803ede70b97b59db)