### PR TITLE
Enable Noctalia Shell for Niri

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -385,6 +385,51 @@
         "type": "github"
       }
     },
+    "noctalia": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ],
+        "noctalia-qs": "noctalia-qs"
+      },
+      "locked": {
+        "lastModified": 1780949817,
+        "narHash": "sha256-2oJuPyt+4dd+ZzO7TFqpmkSAAYpRg9SF4eV8kJGl6Tk=",
+        "owner": "noctalia-dev",
+        "repo": "noctalia",
+        "rev": "f816591afc2f2f606d1f0cf70b51e95c04a7a8aa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "noctalia-dev",
+        "ref": "legacy-v4",
+        "repo": "noctalia",
+        "type": "github"
+      }
+    },
+    "noctalia-qs": {
+      "inputs": {
+        "nixpkgs": [
+          "noctalia",
+          "nixpkgs"
+        ],
+        "systems": "systems_4",
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "lastModified": 1780799499,
+        "narHash": "sha256-YloRtLqJabzYUWvdLyh67zH4DZrR3kQj+dlQJwLPmPM=",
+        "owner": "noctalia-dev",
+        "repo": "noctalia-qs",
+        "rev": "f308426239665e3bc3d624014e9295b2ae2f58ff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "noctalia-dev",
+        "repo": "noctalia-qs",
+        "type": "github"
+      }
+    },
     "nuschtosSearch": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -419,6 +464,7 @@
         "nixpkgs": "nixpkgs_2",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nixvim": "nixvim",
+        "noctalia": "noctalia",
         "sops-nix": "sops-nix"
       }
     },
@@ -487,6 +533,21 @@
         "type": "github"
       }
     },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
+      }
+    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
@@ -501,6 +562,28 @@
         "owner": "numtide",
         "repo": "treefmt-nix",
         "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "noctalia",
+          "noctalia-qs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,10 @@
       url = "github:sodiboo/niri-flake";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    noctalia = {
+      url = "github:noctalia-dev/noctalia/legacy-v4";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
+    };
     handy = {
       url = "github:cjpais/Handy";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
@@ -53,6 +57,7 @@
       nixvim,
       sops-nix,
       niri,
+      noctalia,
       handy,
       kanagawa-yazi,
       ...

--- a/hosts/laptop/default.nix
+++ b/hosts/laptop/default.nix
@@ -87,6 +87,7 @@
     [
       inputs.sops-nix.homeManagerModules.sops
       inputs.handy.homeManagerModules.default
+      inputs.noctalia.homeModules.default
       inputs.nixvim.homeModules.nixvim
       ../../modules/home/kitty.nix
       ../../modules/home/ghostty.nix
@@ -103,7 +104,9 @@
       ../../modules/home/onedriver.nix
 
       ../../modules/home/niri/niri.nix
-      ../../modules/home/niri/waybar.nix
+      # Waybar is replaced by Noctalia Shell. Keep the module around for rollback.
+      # ../../modules/home/niri/waybar.nix
+      ../../modules/home/niri/noctalia.nix
       ../../modules/home/niri/fuzzel.nix
       ../../modules/home/niri/mako.nix
       ../../modules/home/niri/power-menu.nix

--- a/modules/home/niri/niri.nix
+++ b/modules/home/niri/niri.nix
@@ -2,6 +2,9 @@
 # Home Manager configuration for niri Wayland compositor
 { config, pkgs, lib, ... }:
 
+let
+  noctaliaShell = lib.getExe config.programs.noctalia-shell.package;
+in
 {
   programs.niri = {
     settings = {
@@ -19,9 +22,8 @@
         # Mako notification daemon
         { command = [ "systemctl" "--user" "reset-failed" "mako.service" ]; }
         { command = [ "systemctl" "--user" "start" "mako.service" ]; }
-        # Reset waybar service
-        { command = [ "systemctl" "--user" "reset-failed" "waybar.service" ]; }
-        { command = [ "systemctl" "--user" "start" "waybar.service" ]; }
+        # Noctalia Shell replaces Waybar for the Niri panel and desktop shell.
+        { command = [ noctaliaShell ]; }
         # XWayland Satellite for X11 apps (REQUIRED for Niri >= 0.1.10)
         { command = [ "${lib.getExe pkgs.xwayland-satellite}" ]; }
         # Polkit Agent

--- a/modules/home/niri/noctalia.nix
+++ b/modules/home/niri/noctalia.nix
@@ -1,0 +1,37 @@
+# modules/home/niri/noctalia.nix
+# Noctalia Shell configuration for the Niri desktop
+{ ... }:
+
+{
+  programs.noctalia-shell = {
+    enable = true;
+
+    settings = {
+      bar = {
+        position = "top";
+        widgets = {
+          left = [
+            { id = "Launcher"; }
+            { id = "ActiveWindow"; }
+          ];
+          center = [
+            { id = "Workspace"; }
+          ];
+          right = [
+            { id = "Tray"; }
+            { id = "Battery"; }
+            { id = "Volume"; }
+            { id = "Brightness"; }
+            { id = "Clock"; }
+            { id = "ControlCenter"; }
+          ];
+        };
+      };
+
+      location = {
+        name = "Berlin, Germany";
+        use12hourFormat = false;
+      };
+    };
+  };
+}


### PR DESCRIPTION
### Motivation
- Replace Waybar with Noctalia Shell as the panel/desktop shell for the Niri session so the Niri experience uses Noctalia's integrated UI.
- Make Noctalia available as a flake/Home Manager module and start the managed Noctalia executable from the Niri startup sequence.

### Description
- Add the `noctalia` flake input and thread it into `outputs` (and update `flake.lock`).
- Import Noctalia’s Home Manager module into the laptop shared modules and replace the direct `waybar.nix` import with a new `modules/home/niri/noctalia.nix` (the `waybar.nix` line is commented for rollback).
- Update `modules/home/niri/niri.nix` to stop starting the `waybar` systemd/service and instead spawn the Noctalia executable using `lib.getExe config.programs.noctalia-shell.package`.
- Add `modules/home/niri/noctalia.nix` which enables `programs.noctalia-shell` and supplies a basic top-bar widget layout and location settings.

### Testing
- Ran `nix --extra-experimental-features 'nix-command flakes' flake check --no-build` and the flake checks completed successfully.
- Ran `nix --extra-experimental-features 'nix-command flakes' eval .#nixosConfigurations.laptop.config.system.build.toplevel.drvPath` and the toplevel evaluated to a derivation path.
- `nixos-rebuild dry-run --flake .#laptop` could not be executed in this environment because `nixos-rebuild` is not available here.
- `nix fmt`/formatting could not be completed in this environment due to inability to reach `cache.nixos.org`, which caused the formatter run to attempt large source fetches and fail.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b75abcb84832b9a44383f75aad65a)