### PR TITLE
Integrate NiriSwitcher and NiriMod: flake inputs, packages, keybindings and docs

### DIFF
--- a/docs/keyboard-shortcuts/niri-shortcuts.md
+++ b/docs/keyboard-shortcuts/niri-shortcuts.md
@@ -10,6 +10,11 @@ These keyboard shortcuts are configured in `modules/home/niri/niri.nix`.
 |---|---|
 | `Super + Return` | launch terminal (kitty) |
 | `Super + D` | launch application launcher (fuzzel) |
+| `Super + Shift + N` | launch NiriMod config manager |
+| `Alt + Tab` | show NiriSwitcher applications |
+| `Alt + Shift + Tab` | show NiriSwitcher applications in reverse |
+| `Alt + Grave` | show NiriSwitcher workspaces |
+| `Alt + Shift + Grave` | show NiriSwitcher workspaces in reverse |
 | `Right Super + AltGr` | toggle Handy transcription |
 
 ## Window Management (Focus)

--- a/flake.lock
+++ b/flake.lock
@@ -261,6 +261,26 @@
         "type": "github"
       }
     },
+    "nirimod": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780161292,
+        "narHash": "sha256-k9LEaef54u+P2yJXLQP+GtRSXQRSXKEBmszkze7tOfg=",
+        "owner": "srinivasr",
+        "repo": "nirimod",
+        "rev": "f86518f7b2cd13b08591122bd49e770100808313",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srinivasr",
+        "repo": "nirimod",
+        "type": "github"
+      }
+    },
     "nix-darwin": {
       "inputs": {
         "nixpkgs": [
@@ -460,6 +480,7 @@
         "home-manager": "home-manager",
         "kanagawa-yazi": "kanagawa-yazi",
         "niri": "niri",
+        "nirimod": "nirimod",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs_2",
         "nixpkgs-unstable": "nixpkgs-unstable",

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,10 @@
       url = "github:sodiboo/niri-flake";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    nirimod = {
+      url = "github:srinivasr/nirimod";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     noctalia = {
       url = "github:noctalia-dev/noctalia/legacy-v4";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
@@ -57,6 +61,7 @@
       nixvim,
       sops-nix,
       niri,
+      nirimod,
       noctalia,
       handy,
       kanagawa-yazi,

--- a/modules/home/niri/niri.nix
+++ b/modules/home/niri/niri.nix
@@ -1,6 +1,6 @@
 # modules/home/niri/niri.nix
 # Home Manager configuration for niri Wayland compositor
-{ config, pkgs, lib, ... }:
+{ config, pkgs, lib, inputs, ... }:
 
 let
   noctaliaShell = lib.getExe config.programs.noctalia-shell.package;
@@ -30,6 +30,8 @@ in
         { command = [ "${pkgs.polkit_gnome}/libexec/polkit-gnome-authentication-agent-1" ]; }
         # NetworkManager Applet
         { command = [ "${pkgs.networkmanagerapplet}/bin/nm-applet" ]; }
+        # NiriSwitcher daemon for Alt-Tab application switching.
+        { command = [ "${lib.getExe pkgs.niriswitcher}" ]; }
       ];
 
       # Input configuration
@@ -82,8 +84,53 @@ in
         # Mod key (Super/Windows key)
         "Mod+Return".action.spawn = "kitty";
         "Mod+D".action.spawn = "fuzzel";
+        "Mod+Shift+N".action.spawn = "nirimod";
+        "Alt+Tab".action.spawn = [
+          "${lib.getExe' pkgs.glib "gdbus"}"
+          "call"
+          "--session"
+          "--dest"
+          "io.github.isaksamsten.Niriswitcher"
+          "--object-path"
+          "/io/github/isaksamsten/Niriswitcher"
+          "--method"
+          "io.github.isaksamsten.Niriswitcher.application"
+        ];
+        "Alt+Shift+Tab".action.spawn = [
+          "${lib.getExe' pkgs.glib "gdbus"}"
+          "call"
+          "--session"
+          "--dest"
+          "io.github.isaksamsten.Niriswitcher"
+          "--object-path"
+          "/io/github/isaksamsten/Niriswitcher"
+          "--method"
+          "io.github.isaksamsten.Niriswitcher.application"
+        ];
+        "Alt+Grave".action.spawn = [
+          "${lib.getExe' pkgs.glib "gdbus"}"
+          "call"
+          "--session"
+          "--dest"
+          "io.github.isaksamsten.Niriswitcher"
+          "--object-path"
+          "/io/github/isaksamsten/Niriswitcher"
+          "--method"
+          "io.github.isaksamsten.Niriswitcher.workspace"
+        ];
+        "Alt+Shift+Grave".action.spawn = [
+          "${lib.getExe' pkgs.glib "gdbus"}"
+          "call"
+          "--session"
+          "--dest"
+          "io.github.isaksamsten.Niriswitcher"
+          "--object-path"
+          "/io/github/isaksamsten/Niriswitcher"
+          "--method"
+          "io.github.isaksamsten.Niriswitcher.workspace"
+        ];
         "F20".action.spawn = [ "handy" "--toggle-transcription" ];
-        
+
         # Window management
         "Mod+Q".action.close-window = {};
         "Mod+Left".action.focus-column-left = {};
@@ -94,7 +141,7 @@ in
         "Mod+L".action.focus-column-right = {};
         "Mod+K".action.focus-window-up = {};
         "Mod+J".action.focus-window-down = {};
-        
+
         # Move windows
         "Mod+Shift+Left".action.move-column-left = {};
         "Mod+Shift+Right".action.move-column-right = {};
@@ -104,29 +151,29 @@ in
         "Mod+Shift+L".action.move-column-right = {};
         "Mod+Shift+K".action.move-window-up = {};
         "Mod+Shift+J".action.move-window-down = {};
-        
+
         # Move windows between monitors
         "Mod+Ctrl+Alt+Left".action.move-column-to-monitor-left = {};
         "Mod+Ctrl+Alt+Right".action.move-column-to-monitor-right = {};
         "Mod+Ctrl+Alt+H".action.move-column-to-monitor-left = {};
         "Mod+Ctrl+Alt+L".action.move-column-to-monitor-right = {};
-        
+
         # Workspaces
         "Mod+1".action.focus-workspace = 1;
         "Mod+2".action.focus-workspace = 2;
         "Mod+3".action.focus-workspace = 3;
-      
+
         # Move window to workspace
         "Mod+Shift+1".action.move-column-to-workspace = 1;
         "Mod+Shift+2".action.move-column-to-workspace = 2;
         "Mod+Shift+3".action.move-column-to-workspace = 3;
-        
+
         # Column width
         "Mod+R".action.switch-preset-column-width = {};
         "Mod+Shift+R".action.reset-window-height = {};
         "Mod+F".action.maximize-column = {};
         "Mod+Shift+F".action.fullscreen-window = {};
-        
+
         # Misc
         "Mod+Shift+Slash".action.show-hotkey-overlay = {};
         "Mod+Shift+E".action.quit = {};
@@ -148,11 +195,11 @@ in
         # Column merging (Consume/Expel) with ö/ä
         "Mod+odiaeresis".action.consume-or-expel-window-left = {};
         "Mod+adiaeresis".action.consume-or-expel-window-right = {};
-        
+
         # Screenshots
         "Print".action.spawn = ["sh" "-c" "grim -g \"$(slurp)\" - | wl-copy"];
         "Shift+Print".action.spawn = ["sh" "-c" "grim - | wl-copy"];
-        
+
         # Volume/Brightness keys
         "XF86AudioRaiseVolume".action.spawn = ["sh" "-c" "wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+"];
         "XF86AudioLowerVolume".action.spawn = ["sh" "-c" "wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-"];
@@ -192,6 +239,8 @@ in
 
   # Required packages for niri functionality
   home.packages = with pkgs; [
+    inputs.nirimod.packages.${pkgs.system}.default
+    niriswitcher # Niri application/workspace switcher
     swaybg         # Background/wallpaper utility
     grim           # Screenshot tool
     slurp          # Region selector


### PR DESCRIPTION
### Motivation
- Add a configurable application/workspace switcher and a config manager integration to the Niri Wayland setup to provide Alt-Tab style switching and a quick access config UI.
- Add the `nirimod` flake so the Niri configuration manager can be installed and launched from the Niri environment.
- Document the new shortcuts and wire up startup and keybinds so the switcher daemon and associated actions are available on session start.

### Description
- Added new shortcuts to `docs/keyboard-shortcuts/niri-shortcuts.md` for launching `nirimod` and for `Alt+Tab`/`Alt+Grave` switching behaviors.
- Updated `flake.nix` and `flake.lock` to include a `nirimod` input and export it in `outputs`, and added `nirimod` to the root inputs so it can be used in the Home Manager module.
- Modified `modules/home/niri/niri.nix` to accept `inputs`, spawn the `niriswitcher` daemon at startup, add keybindings including `Mod+Shift+N` to spawn `nirimod`, and add `Alt+Tab`/`Alt+Shift+Tab`/`Alt+Grave`/`Alt+Shift+Grave` binds that call the `Niriswitcher` D-Bus methods via `gdbus`; also added `nirimod` and `niriswitcher` to `home.packages`.

### Testing
- No automated tests were run for these configuration and documentation changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b7a7621e8832bb102c6f52a731bac)